### PR TITLE
Fix default value for decred rewards

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
 							<div class="profit-result">
 								<h3> JUNE 2018 MINING REWARD </h3>
 								<div class="result">
-									<p class="amount" id="dcr1-mining-reward-result">150,000</p>
+									<p class="amount" id="dcr1-mining-reward-result">3,750</p>
 									<p class="unit">DCR</p>
 								</div>
 								<div class="result">


### PR DESCRIPTION
Fix default value for decred rewards, as the wrong value is showing on browsers with JavaScript disabled and on IE