### PR TITLE
 Add a countdown timer to the site

### DIFF
--- a/about.html
+++ b/about.html
@@ -45,7 +45,7 @@
 					<li id="colocation-button" class="nav-item">
 						<a class="nav-link" href="colocation.html">COLOCATION</a>
 					</li>
-					<li id="preorder-button" class="nav-item">
+					<li id="preorder-button" class="nav-item no-disp-when-sale-closed">
 						<a class="nav-link" href="preorder.html">PREORDER</a>
 					</li>
 				</ul>
@@ -85,7 +85,7 @@
 				<li>
 					<a href="colocation.html">COLOCATION</a>
 				</li>
-				<li>
+				<li class="no-disp-when-sale-closed">
 					<a href="preorder.html">PREORDER</a>
 				</li>
 				<li>
@@ -200,6 +200,7 @@
 	</div>
 	<script src="assets/js/jquery.min.js"></script>
 	<script src="assets/js/bootstrap.min.js"></script>
+	<script src="js/main.js"></script>
 	<!-- BEGIN GROOVE WIDGET CODE -->
 
 	<script id="grv-widget">

--- a/assets/css/obelisk.css
+++ b/assets/css/obelisk.css
@@ -979,6 +979,7 @@ body {
 .ordercount-product-label {
 	font-size: 42px;
 }
+
 .red-gradient-text {
 	background-image: -webkit-linear-gradient(top, #ff0000, #230000); /* For Chrome and Safari */
     background-image:    -moz-linear-gradient(top, #ff0000, #230000); /* For old Fx (3.6 to 15) */
@@ -1251,4 +1252,42 @@ a.colo-table-link:hover {
 
 .red-color {
 	color: #e4001b;
+}
+
+.countdown-container {
+	display: inline-block;
+	vertical-align: middle;
+	position: relative;
+	top: -2px;
+	float: right;
+    width: 154px;
+}
+
+.countdown-msg {
+	color: #666666;
+	font-size: 16px;
+}
+
+.countdown-hhmmss {
+	color: #404040;
+	font-size: 16px;
+	position: relative;
+	top: -20px;
+}
+
+.countdown-hh {
+	margin-left: 10px;
+}
+	
+.countdown-mm {
+	margin-left: 24px;
+}
+	
+.countdown-ss {
+	margin-left: 30px;
+}
+	
+.countdown-timer {
+	font-size: 48px;
+	font-family: "Karbon Regular";
 }

--- a/colocation.html
+++ b/colocation.html
@@ -45,7 +45,7 @@
                     <li id="colocation-button" class="nav-item active">
                         <a class="nav-link" href="#">COLOCATION</a>
                     </li>
-                    <li id="preorder-button" class="nav-item">
+                    <li id="preorder-button" class="nav-item no-disp-when-sale-closed">
                         <a class="nav-link" href="preorder.html">PREORDER</a>
                     </li>
                 </ul>
@@ -85,7 +85,7 @@
                 <li class="active">
                     <a href="colocation.html">COLOCATION</a>
                 </li>
-                <li>
+                <li class="no-disp-when-sale-closed">
                     <a href="preorder.html">PREORDER</a>
                 </li>
                 <li>
@@ -377,6 +377,7 @@
     </div>
     <script src="assets/js/jquery.min.js "></script>
     <script src="assets/js/bootstrap.min.js "></script>
+    <script src="js/main.js"></script>
     <!-- BEGIN GROOVE WIDGET CODE -->
 
     <script id="grv-widget">

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 					<li id="colocation-button" class="nav-item">
 						<a class="nav-link" href="colocation.html">COLOCATION</a>
 					</li>
-					<li id="preorder-button" class="nav-item">
+					<li id="preorder-button" class="nav-item no-disp-when-sale-closed">
 						<a class="nav-link" href="preorder.html">PREORDER</a>
 					</li>
 				</ul>
@@ -101,8 +101,24 @@
 	</div>
 	<div class="container main">
 		<div class="row">
-			<div class="col-md-6">
+			<div class="col-xs-6 col-sm-5 col-md-3 col-lg-3">
 				<img class="obelisk-header" src="assets/img/obelisk-text.png" />
+			</div>
+			<div class="col-xs-6 col-sm-5 col-md-4 col-lg-3">
+				<div id="countdown-container" class="countdown-container">
+					<div class="countdown-msg hide-when-sale-closed">SALE ENDS IN:</div>
+					<div id="countdown-timer" class="countdown-timer red-gradient-text">00:00:00</div>
+					<div class="countdown-hhmmss hide-when-sale-closed">
+						<span class="countdown-hh">HH</span>
+						<span class="countdown-mm">MM</span>
+						<span class="countdown-ss">SS</span>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<div class="row">
+			<div class="col-sm-12 col-md-7 col-lg-6">
 				<div class="separator"></div>
 				<h3 class="something-big"> HIGH PERFORMANCE ASIC MINERS FOR
 					<span class=" red-gradient-text">DECRED</span> AND
@@ -142,7 +158,7 @@
 				<div class="red-separator"></div>
 				<div class="separator"></div>
 			</div>
-			<div class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
+			<div class="col-lg-2 col-md-2 col-sm-4 col-xs-10 hide-when-sale-closed">
 				<a href="preorder.html" class="preorder-button">PREORDER</a>
 			</div>
 		</div>
@@ -241,7 +257,7 @@
 					<div class="price">
 						<span class="price-dollar">$</span>2,499
 					</div>
-					<a href="preorder.html" class="preorder-button">PREORDER</a>
+					<a href="preorder.html" class="preorder-button hide-when-sale-closed">PREORDER</a>
 				</div>
 				</br>
 				<h4> 28NM FULL CUSTOM ASIC </h4>

--- a/js/main.js
+++ b/js/main.js
@@ -59,3 +59,44 @@ $('#sc1-sell-cap').text(formatNumber(sc1SellCap))
 $('.order-bar-dcr1-inner').css('width', dcr1Sold / dcr1SellCap * 100 + '%')
 $('#dcr1-sold').text(formatNumber(dcr1Sold))
 $('#dcr1-sell-cap').text(formatNumber(dcr1SellCap))
+
+var saleEndTime = Date.UTC(2017, 10, 25, 5, 0, 0)
+var isSaleOver = false
+
+var MS_PER_SEC = 1000
+var MS_PER_MIN = MS_PER_SEC * 60
+var MS_PER_HOUR = MS_PER_MIN * 60
+
+// Countdown timer
+var updatePresaleTimer = function() {
+  var currTime = new Date()
+  var timeRemaining = saleEndTime - currTime.getTime()
+  if (timeRemaining <= 0) {
+    $('#countdown-timer').text('SALE OVER')
+    $('#countdown-container').css('width', '230px')
+    $('.hide-when-sale-closed').css('visibility', 'hidden')
+    $('.no-disp-when-sale-closed').css('display', 'none')
+    clearInterval(interval)
+    return
+  }
+
+  var hours = Math.floor(timeRemaining / MS_PER_HOUR)
+  timeRemaining -= hours * MS_PER_HOUR
+
+  var mins = Math.floor(timeRemaining / MS_PER_MIN)
+  timeRemaining -= mins * MS_PER_MIN
+
+  var secs = Math.floor(timeRemaining / MS_PER_SEC)
+  timeRemaining -= secs * MS_PER_SEC
+
+  var timeString = ''
+  timeString += (hours < 10 ? '0' + hours : hours) + ':'
+  timeString += (mins < 10 ? '0' + mins : mins) + ':'
+  timeString += secs < 10 ? '0' + secs : secs
+
+  $('#countdown-timer').text(timeString)
+}
+
+var interval = setInterval(updatePresaleTimer, 1000)
+
+updatePresaleTimer()

--- a/preorder.html
+++ b/preorder.html
@@ -45,7 +45,7 @@
 					<li id="colocation-button" class="nav-item">
 						<a class="nav-link" href="colocation.html">COLOCATION</a>
 					</li>
-					<li id="preorder-button" class="nav-item active">
+					<li id="preorder-button" class="nav-item active no-disp-when-sale-closed">
 						<a class="nav-link" href="#">PREORDER</a>
 					</li>
 				</ul>
@@ -85,7 +85,7 @@
 				<li>
 					<a href="colocation.html">COLOCATION</a>
 				</li>
-				<li class="active">
+				<li class="active no-disp-when-sale-closed">
 					<a href="preorder.html">PREORDER</a>
 				</li>
 				<li>
@@ -98,7 +98,7 @@
 		<div class="frameline-left"></div>
 		<div class="frameline-right"></div>
 	</div>
-	<div class="container preorder-main">
+	<div class="container preorder-main no-disp-when-sale-closed">
 		<div class="row">
 			<div class="col-md-12">
 				<h3 class="preorder-title">CHOOSE AN OBELISK TO PREORDER</h3>


### PR DESCRIPTION
The timer will hide all preorder buttons and links when the sale is over.
It uses UTC times so the user's timezone doesn't matter.
The user could set their clock back to show the preorder buttons though, so we need to make some server changes too to totally prevent new orders.