### PR TITLE
Fix team responsive layout on mobile

### DIFF
--- a/assets/css/obelisk.css
+++ b/assets/css/obelisk.css
@@ -1228,6 +1228,7 @@ a.colo-table-link:hover {
 .team-member-image {
 	width: 45%;
 	margin-bottom: 5px;
+	height: 144px;
 }
 
 


### PR DESCRIPTION
This should really be fixed by getting Marti to re-export the images at exactly the same sizes (144x144).